### PR TITLE
Platform 3062 - only support STATIC items

### DIFF
--- a/src/entities/services/item.service.ts
+++ b/src/entities/services/item.service.ts
@@ -14,7 +14,6 @@ interface ItemDTOInternal {
     name: string,
     rarity: number | null,
     version: string,
-    skn: string,
 }
 
 export interface ItemDTO {
@@ -29,7 +28,6 @@ export interface ItemDTO {
     name: string,
     rarity: number | null,
     version: string,
-    skn: string,
 }
 
 export interface CardDTO {

--- a/src/images/controllers/images.controller.ts
+++ b/src/images/controllers/images.controller.ts
@@ -40,16 +40,6 @@ export class ImagesController {
                 dto = await this.skuService.get(code);
             } else {
                 dto = await this.itemService.get(code);
-
-                if (dto.skn !== "STATIC") {
-                    logger.error(`skn property of item '${code}' is '${dto.skn}'. Flex only supports 'STATIC' items`);
-                    response.writeHead(StatusCodes.BAD_REQUEST);
-                    response.write('Failed to draw image');
-                    response.end();
-                    return;
-                }
-
-
             }
 
             const version = request.params.version;


### PR DESCRIPTION
PLATFORM-3062 - change to use drm-get-item
PLATFORM-2986 - only support STATIC items (reverted)
